### PR TITLE
Add todo.txt Skill for AI Agents

### DIFF
--- a/MORE.md
+++ b/MORE.md
@@ -6,3 +6,5 @@
 [**CleanUpTxt**](https://cleanuptxt.com) - fast and privacy friendly text cleaning and formatting tools that run locally in the browser
 
 [**Flipper File**](https://flipperfile.com/text-tools/txt) - free browser-based TXT file compression tool (GZIP or Deflate), no login required
+
+[**todo.txt Skill for AI Agents**](https://github.com/aguilera-ee/todo.txt-skill) - manage a durable todo.txt task list conversationally by driving the official todo.sh CLI


### PR DESCRIPTION
Adds an entry under Tools in MORE.md, following the 2026 policy for generic .TXT tools and services.

It lets an AI agent manage a durable todo.txt task list by driving the official todo.sh CLI. Source is on GitHub: https://github.com/aguilera-ee/todo.txt-skill